### PR TITLE
ApiControllerの呼び出しをモジュール化

### DIFF
--- a/api/controllers/ArticleController.js
+++ b/api/controllers/ArticleController.js
@@ -12,11 +12,7 @@ module.exports = {
       return res.send(400);
     }
 
-    sails.controllers['api/article']._findArticles({page: page}, function(error, articles) {
-      if (error) {
-        return res.send(500);
-      }
-
+    sails.api('article').find(req, function(err, articles) {
       res.view('homepage', {articles: articles});
     });
   }

--- a/api/controllers/api/ArticleController.js
+++ b/api/controllers/api/ArticleController.js
@@ -15,18 +15,12 @@ module.exports = {
 			return res.send(400);
 		}
 
-		this._findArticles({page: page}, function(error, articles) {
+		Article.find().exec(function(error, articles) {
 			if (error) {
 				return res.send(500);
 			}
 
 			res.send(articles);
-		});
-	},
-	// CallbackでJSONを返す内部関数
-	_findArticles: function(data, callback) {
-		Article.find().exec(function(error, articles) {
-			callback(error, articles);
 		});
 	}
 };

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -11,6 +11,32 @@
 
 module.exports.bootstrap = function(cb) {
 
+  sails.api = function(controller) {
+    var func = {};
+
+    var controller = sails.controllers['api/' + controller];
+
+    for (var key in controller) {
+      if (typeof controller[key] === 'function') {
+        func[key] = function(key) {
+          return function (req, callback) {
+            controller[key](req, {
+              send: function(result) {
+                if (typeof result !== 'object') {
+                  return callback(result, null);
+                }
+
+                callback(null, result);
+              }
+            });
+          };
+        }(key);
+      }
+    }
+
+    return func;
+  };
+
   // It's very important to trigger this callback method when you are finished
   // with the bootstrap!  (otherwise your server will never lift, since it's waiting on the bootstrap)
   cb();


### PR DESCRIPTION
ApiControllerの呼び出しをprivate関数を使わずにできるようにしました。
sailsのnamespaceにオリジナルメソッドを追加しているのは微妙な気もしますが。
callbackのところをpromise化したいですがまた今度。
